### PR TITLE
Implement iterate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ userdb {
 
 # then in auth.conf
 uri = proxy:/tmp/podop.socket:auth
-iterate_disable = yes
+iterate_prefix = userdb/
 default_pass_scheme = plain
 password_key = passdb/%u
 user_key = userdb/%u


### PR DESCRIPTION
Implement Dovecots Dict Protocol `iterate` command, as described in [Dict Protocol](https://doc.dovecot.org/developer_manual/design/dict_protocol/), to provide user listing support to Dovecot (all `doveadm` commands supporting wildcards or `-A` arguments).

Only the `NO_VALUE` flag is processed yet, as Dovecot seems not to use flags at all for its queries (at least I wasn't able to trigger and therefore properly test them).

Note that while the provided code works, there are probably better ways to express it.